### PR TITLE
Changed to scigraph loader for GO

### DIFF
--- a/src/main/resources/monarchLoadConfiguration.yaml.tmpl
+++ b/src/main/resources/monarchLoadConfiguration.yaml.tmpl
@@ -78,6 +78,7 @@ categories:
     http://purl.obolibrary.org/obo/CHEBI_23888 : drug
     http://purl.obolibrary.org/obo/UPHENO_0001001 : Phenotype
     http://purl.obolibrary.org/obo/GO_0008150 : biological process
+    http://purl.obolibrary.org/obo/GO_0009987 : cellular process
     http://purl.obolibrary.org/obo/GO_0005575 : cellular component
     http://purl.obolibrary.org/obo/GO_0003674 : molecular function
     http://purl.obolibrary.org/obo/SO_0000704 : gene

--- a/src/main/resources/monarchLoadConfiguration.yaml.tmpl
+++ b/src/main/resources/monarchLoadConfiguration.yaml.tmpl
@@ -53,6 +53,7 @@ ontologies:
   - url: http://purl.obolibrary.org/obo/ero.owl
   - url: http://purl.obolibrary.org/obo/pw.owl
   - url: https://raw.githubusercontent.com/jamesmalone/OBAN/master/ontology/oban_core.ttl
+  - url: https://build.berkeleybop.org/job/build-combined-noctua-models/lastSuccessfulBuild/artifact/noctua-models.owl
   # clo.owl is missing and import
   #- url: http://purl.obolibrary.org/obo/clo.owl
   - url: http://purl.obolibrary.org/obo/pco.owl
@@ -76,8 +77,9 @@ categories:
     #http://purl.obolibrary.org/obo/CHEBI_23367 : molecular entity
     http://purl.obolibrary.org/obo/CHEBI_23888 : drug
     http://purl.obolibrary.org/obo/UPHENO_0001001 : Phenotype
-    #http://purl.obolibrary.org/obo/GO_0008150 : biological process
-    #http://purl.obolibrary.org/obo/GO_0005575 : cellular component
+    http://purl.obolibrary.org/obo/GO_0008150 : biological process
+    http://purl.obolibrary.org/obo/GO_0005575 : cellular component
+    http://purl.obolibrary.org/obo/GO_0003674 : molecular function
     http://purl.obolibrary.org/obo/SO_0000704 : gene
     http://purl.obolibrary.org/obo/GENO_0000536 : genotype
     http://purl.obolibrary.org/obo/GENO_0000504 : reagent targeted gene


### PR DESCRIPTION
Added GO noctua models (these will not be visible in the monarch app). See https://github.com/geneontology/go-site/issues/169

Also added categories for GO roots
