### PR TITLE
Download local copy of rdf and owl files in docker container

### DIFF
--- a/src/main/resources/Dockerfile-load
+++ b/src/main/resources/Dockerfile-load
@@ -37,4 +37,6 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 # Define default command.
 RUN git clone https://github.com/SciGraph/SciGraph.git /data/scigraph
 RUN cd /data/scigraph && mvn install -DskipTests -DskipITs
+RUN wget -r -l1 -nH --no-parent -R "index.html*" https://data.monarchinitiative.org/ttl/
+RUN wget -r -l1 -nH --no-parent -R "index.html*" https://data.monarchinitiative.org/owl/
 CMD cd /data/scigraph/SciGraph-core && export MAVEN_OPTS="-Xmx125g -XX:MaxPermSize=125g" && mvn exec:java -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c /data/monarch-load-config.yaml"

--- a/src/main/resources/monarchLoadConfiguration.yaml.tmpl
+++ b/src/main/resources/monarchLoadConfiguration.yaml.tmpl
@@ -14,7 +14,7 @@ graphConfiguration:
 
 ontologies:
   # Monarch ontology
-  - url: https://data.monarchinitiative.org/owl/monarch-merged.owl
+  - url: /data/owl/monarch-merged.owl
     reasonerConfiguration:
       factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
       addDirectInferredEdges: true
@@ -29,43 +29,43 @@ ontologies:
       removeUnsatisfiableClasses: true
   
   # Data sources
-  - url: https://data.monarchinitiative.org/ttl/mgi.ttl
-  - url: https://data.monarchinitiative.org/ttl/panther.ttl
-  - url: https://data.monarchinitiative.org/ttl/clinvar.ttl
-  - url: https://data.monarchinitiative.org/ttl/ncbigene.ttl
-  - url: https://data.monarchinitiative.org/ttl/biogrid.ttl
-  - url: https://data.monarchinitiative.org/ttl/zfin.ttl
-  - url: https://data.monarchinitiative.org/ttl/ctd.ttl
-  - url: https://data.monarchinitiative.org/ttl/hpoa.ttl
-  - url: https://data.monarchinitiative.org/ttl/omim.ttl
-  - url: https://data.monarchinitiative.org/ttl/coriell.ttl
-  - url: https://data.monarchinitiative.org/ttl/hgnc.ttl
-  #- url: http://data.monarchinitiative.org/ttl/kegg.ttl
-  - url: https://data.monarchinitiative.org/ttl/impc.ttl
-  - url: https://data.monarchinitiative.org/ttl/ucscbands.ttl
-  - url: https://data.monarchinitiative.org/ttl/monochrom.ttl
-  - url: https://data.monarchinitiative.org/ttl/eom.ttl
+  - url: /data/ttl/mgi.ttl
+  - url: /data/ttl/panther.ttl
+  - url: /data/ttl/clinvar.ttl
+  - url: /data/ttl/ncbigene.ttl
+  - url: /data/ttl/biogrid.ttl
+  - url: /data/ttl/zfin.ttl
+  - url: /data/ttl/ctd.ttl
+  - url: /data/ttl/hpoa.ttl
+  - url: /data/ttl/omim.ttl
+  - url: /data/ttl/coriell.ttl
+  - url: /data/ttl/hgnc.ttl
+  - url: /data/ttl/impc.ttl
+  - url: /data/ttl/ucscbands.ttl
+  - url: /data/ttl/monochrom.ttl
+  - url: /data/ttl/eom.ttl
   #- url: http://data.monarchinitiative.org/ttl/genereviews.ttl
-  - url: https://data.monarchinitiative.org/ttl/orphanet.ttl
-  - url: https://data.monarchinitiative.org/ttl/animalqtldb.ttl
-  - url: https://data.monarchinitiative.org/ttl/flybase.nt
-  - url: https://data.monarchinitiative.org/ttl/wormbase.nt
-  - url: https://data.monarchinitiative.org/ttl/omia.ttl
-  - url: https://data.monarchinitiative.org/ttl/mmrrc.ttl
-  - url: https://data.monarchinitiative.org/ttl/gwascatalog.ttl
-  - url: https://data.monarchinitiative.org/ttl/monarch.ttl
-  - url: https://data.monarchinitiative.org/ttl/mpd.ttl
-  - url: https://data.monarchinitiative.org/ttl/go.ttl
-  - url: https://data.monarchinitiative.org/ttl/mgi_slim.ttl
-  - url: https://data.monarchinitiative.org/ttl/zfinslim.ttl
-  - url: https://data.monarchinitiative.org/ttl/reactome.ttl
-  - url: https://data.monarchinitiative.org/ttl/udp.ttl
-  - url: https://data.monarchinitiative.org/ttl/bgee.ttl
-  - url: https://data.monarchinitiative.org/ttl/string.ttl
-  - url: https://data.monarchinitiative.org/ttl/ensembl.ttl
-  - url: https://data.monarchinitiative.org/ttl/rgd.ttl
-  - url: https://data.monarchinitiative.org/ttl/sgd.ttl
-  - url: https://data.monarchinitiative.org/ttl/mychem.ttl
+  - url: /data/ttl/orphanet.ttl
+  - url: /data/ttl/animalqtldb.ttl
+  - url: /data/ttl/flybase.nt
+  - url: /data/ttl/wormbase.nt
+  - url: /data/ttl/omia.ttl
+  - url: /data/ttl/mmrrc.ttl
+  - url: /data/ttl/gwascatalog.ttl
+  - url: /data/ttl/monarch.ttl
+  - url: /data/ttl/mpd.ttl
+  - url: /data/ttl/go.ttl
+  - url: /data/ttl/mgi_slim.ttl
+  - url: /data/ttl/zfinslim.ttl
+  - url: /data/ttl/reactome.ttl
+  - url: /data/ttl/udp.ttl
+  - url: /data/ttl/bgee.ttl
+  - url: /data/ttl/string.ttl
+  - url: /data/ttl/ensembl.ttl
+  - url: /data/ttl/rgd.ttl
+  - url: /data/ttl/sgd.ttl
+  - url: /data/ttl/mychem.ttl
+  - url: /data/ttl/kegg.ttl
   
   # Other ontologies
   - url: http://biohackathon.org/resource/faldo.ttl
@@ -76,7 +76,7 @@ ontologies:
   - url: http://purl.obolibrary.org/obo/pw.owl
   - url: https://raw.githubusercontent.com/jamesmalone/OBAN/master/ontology/oban_core.ttl
   #- url: http://build.berkeleybop.org/job/build-combined-noctua-models/lastSuccessfulBuild/artifact/noctua-models-noimport.owl
-  - url: https://data.monarchinitiative.org/owl/clo_core.owl
+  - url: /data/owl/clo_core.owl
   - url: http://purl.obolibrary.org/obo/pco.owl
   - url: http://purl.obolibrary.org/obo/xco.owl
   - url: http://xmlns.com/foaf/spec/index.rdf


### PR DESCRIPTION
Adjusts the dockerfile to download the monarch ontology and data files and then refer to them locally in the scigraph config.